### PR TITLE
Added 'try_sudo' prefixes to drupal.rb 'run' commands to prevent permissions issues.

### DIFF
--- a/capistrano-ash.gemspec
+++ b/capistrano-ash.gemspec
@@ -5,7 +5,7 @@
 
 Gem::Specification.new do |s|
   s.name = "capistrano-ash"
-  s.version = "1.2.0"
+  s.version = "1.2.4"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["August Ash"]


### PR DESCRIPTION
At the moment all 'run' commands in drupal.rb do not prefix the 'try_sudo' variable which causes permissions errors all over the place.

This patch should fix a lot of that.
