### PR TITLE
Improve set_perms_* performance

### DIFF
--- a/lib/ash/common.rb
+++ b/lib/ash/common.rb
@@ -44,10 +44,10 @@ end
 
 # set the permissions for files recurisvely from the starting directory (dir_path) 
 def set_perms_files(dir_path, perm = 644)
-  try_sudo "find #{dir_path} -type f -exec chmod #{perm} {} \\;"
+  try_sudo "find #{dir_path} -type f -print0 | xargs -0 chmod #{perm}"
 end
 
 # set the permissions for directories recurisvely from the starting directory (dir_path) 
 def set_perms_dirs(dir_path, perm = 755)
-  try_sudo "find #{dir_path} -type d -exec chmod #{perm} {} \\;"
+  try_sudo "find #{dir_path} -type d -print0 | xargs -0 chmod #{perm}"
 end


### PR DESCRIPTION
Setting perms on a large file tree takes forever, this improves the time drastically.

Example for directories on a Magento project:

Before:

```
ubuntu@staging:/var/www/app/current$ time find /var/www/app/releases/20130718121318 -type d -exec chmod 755 {} \;

real    0m34.930s
user    0m2.792s
sys 0m23.441s
```

After:

```
ubuntu@staging:/var/www/app/current$ time find /var/www/app/releases/20130718121318 -type d -print0 | xargs -0 chmod 755

real    0m0.264s
user    0m0.052s
sys 0m0.196s
```
