### PR TITLE
Only write robots.txt in production if not supplied.

### DIFF
--- a/lib/ash/base.rb
+++ b/lib/ash/base.rb
@@ -301,7 +301,9 @@ EOF
       end
 
       # echo the file out into the root of the latest_release directory
-      put robots_txt, "#{latest_release}/robots.txt"
+      if "#{stage}" != 'production' or !remote_file_exists?("#{latest_release}/robots.txt")
+        put robots_txt, "#{latest_release}/robots.txt"
+      end
     end
   end
 


### PR DESCRIPTION
I have not fully tested this Pull Request.

But code something like this should be made to fix #54 which stops vendor-supplied or project-supplied robots.txt from being used in production.  The staging robots.txt is perfect, but if there's already another robots.txt in the repo, then it's better to use that than the very basic production one.
